### PR TITLE
Update 2018_02_16_134508_create_workflow_guard_table.php

### DIFF
--- a/src/database/migrations/2018_02_16_134508_create_workflow_guard_table.php
+++ b/src/database/migrations/2018_02_16_134508_create_workflow_guard_table.php
@@ -33,6 +33,6 @@ class CreateWorkflowGuardTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('worfklow_guards');
+        Schema::dropIfExists('workflow_guards');
     }
 }


### PR DESCRIPTION
fix typo table name on drop if exist